### PR TITLE
Removing dead link to cet-quickstart (+ allowing issues?

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ Or
 npm install pj-custom-electron-titlebar@latest
 ```
 
-or use the base project [cet-quickstart](https://github.com/AlexTorresSk/cet-quickstart)
-
 ## Usage
 
 In your renderer file or in an HTML script tag add:


### PR DESCRIPTION
Seems like the link to cet-quickstart was already dead in https://github.com/AlexTorresSk/custom-electron-titlebar.

Question: could you allow the issue function for your repo to make it possible to others to create issues.
The 'Contributing' section in your readme makes otherwise no sense ;)

Greetings.